### PR TITLE
Standard-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,6 @@
       "git add"
     ]
   },
-  "standard-version": {
-    "skip": {
-      "commit": true
-    }
-  },
   "dependencies": {
     "commander": "^2.16.0",
     "cowsay": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,7 @@
     "check": "tsc --noEmit",
     "lint": "tslint -p . -c tslint.json --fix",
     "build": "npm run check && npm run lint && tsc",
-    "release:tags": "git push && git push --tags",
-    "release:patch": "npm version patch && npm run release:tags",
-    "release:minor": "npm version minor && npm run release:tags",
-    "release:major": "npm version major && npm run release:tags"
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -48,6 +45,11 @@
       "git add"
     ]
   },
+  "standard-version": {
+    "skip": {
+      "commit": true
+    }
+  },
   "dependencies": {
     "commander": "^2.16.0",
     "cowsay": "^1.3.1",
@@ -66,6 +68,7 @@
     "execa": "^1.0.0",
     "husky": "^1.1.2",
     "lint-staged": "^7.3.0",
+    "standard-version": "^7.0.0",
     "tslint": "^5.11.0",
     "typescript": "^3.0.1"
   }


### PR DESCRIPTION
Guys, I hope you can accept this PR and apply it in all other releasable packages.

[standard-version](https://github.com/conventional-changelog/standard-version)

After having it installed, it will handle tags, version bumps, changelog creation/updates, and commit everything.

The last step missing will be publish the new version :)

If you guys want to disable any steps, all you have to do is add the skipped steps on your `package.json`, like:

```json
  "standard-version": {
    "skip": {
      "commit": true
    }
  },
```

I **strongly** suggest you guys to do two things:

* Enforce the usage of a commit message convention.
* **NEVER** generate a new release if the PR was not accepted yet. Meaning that anyone should create a PR, have it CR-ed and, when approved, the same PR creator should release the new version using the command `npm run release` (no more `npm run release:my-dump-ass-shit-of-commands`.

Cheers mofo.

P.S.: @vilaboim is hot.